### PR TITLE
fix: 修复上传目录和缩略图的名称

### DIFF
--- a/config/setting.go
+++ b/config/setting.go
@@ -27,6 +27,6 @@ func init() {
 func Init() {
 	BaseDir, _ = filepath.Abs(BaseDir)                                         // 绝对路径
 	DownloadDir = path.Join(BaseDir, "upload")                                 // 下载目录
-	UploadPicStore = path.Join(BaseDir, "upload", "pictrue")                   // 上传图片保存的正式目录
-	UploadPicStoreThumbnail = path.Join(BaseDir, "upload", "pictruethumbnail") // 上传图片保存的缩略图目录
+	UploadPicStore = path.Join(BaseDir, "upload", "origin")                    // 上传图片保存的正式目录, 保存原始图片
+	UploadPicStoreThumbnail = path.Join(BaseDir, "upload", "thumbnail")        // 上传图片保存的缩略图目录
 }


### PR DESCRIPTION
``pictrue`` 拼写错误，应该是``picture``
``pictruethumbnail``应该是``picturethumbnail``

picture更名为origin，表示上传的原始图片，更贴切
picturethumbnail更名为thumbnail